### PR TITLE
Add connection pooling

### DIFF
--- a/MODULE.md
+++ b/MODULE.md
@@ -112,6 +112,15 @@ withConnection :: forall eff a. ConnectionInfo -> (Client -> Aff (db :: DB | eff
 Connects to the database, calls the provided function with the client
 and returns the results.
 
+#### `withClient`
+
+``` purescript
+withClient :: forall eff a. ConnectionInfo -> (Client -> Aff (db :: DB | eff) a) -> Aff (db :: DB | eff) a
+```
+
+Takes a Client from the connection pool, runs the given function with
+the client and returns the results.
+
 #### `end`
 
 ``` purescript

--- a/MODULE.md
+++ b/MODULE.md
@@ -119,6 +119,13 @@ end :: forall eff. Client -> Eff (db :: DB | eff) Unit
 ```
 
 
+#### `disconnect`
+
+``` purescript
+disconnect :: forall eff. Eff (db :: DB | eff) Unit
+```
+
+
 
 ## Module Database.Postgres.SqlValue
 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -26,6 +26,8 @@ main = runAff (trace <<< show) (const $ trace "All ok") $ do
 
   exampleQueries
 
+  liftEff $ disconnect
+
 data Artist = Artist
   { name :: String
   , year :: Number

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -65,7 +65,7 @@ exampleError = withConnection connectionInfo $ \c -> do
   queryOne_ (Query "select year from artist") c
 
 exampleQueries :: forall eff. Aff (trace :: Trace, db :: DB | eff) Unit
-exampleQueries = withConnection connectionInfo $ \c -> do
+exampleQueries = withClient connectionInfo $ \c -> do
   liftEff $ trace "Example queries with params:"
   execute_ (Query "delete from artist") c
   execute_ (Query "insert into artist values ('Led Zeppelin', 1968)") c


### PR DESCRIPTION
Use connection pooling with `withConnection` and add `disconnect` for disconnecting all connections.

Fixes #4, but requires some work on configuring the pool.
