### PR TITLE
Add IsSqlValue class to Arrays of IsSqlValues

### DIFF
--- a/MODULE.md
+++ b/MODULE.md
@@ -195,6 +195,13 @@ instance isSqlValueMaybe :: (IsSqlValue a) => IsSqlValue (Maybe a)
 ```
 
 
+#### `isSqlValueArray`
+
+``` purescript
+instance isSqlValueArray :: (IsSqlValue a) => IsSqlValue (Array a)
+```
+
+
 
 ## Module Database.Postgres.Transaction
 

--- a/src/Database/Postgres/SqlValue.purs
+++ b/src/Database/Postgres/SqlValue.purs
@@ -31,6 +31,9 @@ instance isSqlValueInt :: IsSqlValue Int where
 instance isSqlValueMaybe :: (IsSqlValue a) => IsSqlValue (Maybe a) where
   toSql = unsafeCoerce <<< toNullable <<< (toSql <$> _)
 
+instance isSqlValueArray :: (IsSqlValue a) => IsSqlValue (Array a) where
+  toSql = unsafeCoerce <<< map toSql
+
 instance isSqlValueDateTime :: IsSqlValue DateTime where
   toSql = toSql <<< format
     where

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -128,6 +128,17 @@ main = run [consoleReporter] do
         ) dt
         liftEff $ end pool
 
+  describe "sql arrays as parameters" $
+    it "can be passed as a SqlValue" do
+      pool <- liftEff $ mkPool connectionInfo
+      withClient pool \c -> do
+        execute_ (Query "delete from artist") c
+        execute_ (Query "insert into artist values ('Zed Leppelin', 1967)") c
+        execute_ (Query "insert into artist values ('Led Zeppelin', 1968)") c
+        execute_ (Query "insert into artist values ('Deep Purple', 1969)") c
+        artists <- query (Query "select * from artist where year = any ($1)" :: Query Artist) [toSql [1968, 1969]] c
+        length artists `shouldEqual` 2
+        liftEff $ end pool
 
   describe "transactions" do
     it "does not commit after an error inside a transation" do


### PR DESCRIPTION
PostgreSQL and node-postgres allow for array values to be passed in as parameters. Adding the `IsSqlValue` type class to `Array`s of `IsSqlValue` is all that's needed to make this work.