### PR TITLE
updates for 0.12, remove foreign-generics

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,22 +26,21 @@
     "output"
   ],
   "dependencies": {
-    "purescript-arrays": "^4.2.1",
-    "purescript-either": "^3.1.0",
-    "purescript-foreign": "^4.0.1",
-    "purescript-foldable-traversable": "^3.6.1",
-    "purescript-transformers": "^3.4.0",
-    "purescript-aff": "^4.0.0",
-    "purescript-integers": "^3.1.0",
-    "purescript-datetime": "^3.4.0",
-    "purescript-unsafe-coerce": "^3.0.0",
-    "purescript-nullable": "^3.0.0",
-    "purescript-prelude": "^3.1.0",
-    "purescript-foreign-generic": "^5.0.0"
+    "purescript-arrays": "^5.0.0",
+    "purescript-either": "^4.0.0",
+    "purescript-foreign": "^5.0.0",
+    "purescript-foldable-traversable": "^4.0.0",
+    "purescript-transformers": "^4.1.0",
+    "purescript-aff": "^5.0.0",
+    "purescript-integers": "^4.0.0",
+    "purescript-datetime": "^4.0.0",
+    "purescript-unsafe-coerce": "^4.0.0",
+    "purescript-nullable": "^4.0.0",
+    "purescript-prelude": "^4.0.0"
   },
   "devDependencies": {
-    "purescript-spec": "^2.0.0",
-    "purescript-generics": "^4.0.0",
-    "purescript-js-date": "^5.1.0"
+    "purescript-spec": "^3.0.0",
+    "purescript-js-date": "^6.0.0",
+    "purescript-simple-json": "^4.0.0"
   }
 }


### PR DESCRIPTION
Foreign-Generics won't be updated for a while, but the usages here seem to be leftover from pre-11.6 days. I updated this to have the user supply their own decoding function, and updated the tests to use Simple-JSON.