### PR TITLE
Remove primes from foreign modules exports

### DIFF
--- a/src/Database/Postgres.js
+++ b/src/Database/Postgres.js
@@ -9,7 +9,7 @@ exports.mkPool = function (conInfo) {
   };
 }
 
-exports["connect'"] = function (pool) {
+exports.connectImpl = function (pool) {
   return function(error, success) {
     pool.connect(function(err, client) {
       if (err) {

--- a/src/Database/Postgres.purs
+++ b/src/Database/Postgres.purs
@@ -85,7 +85,7 @@ connectionInfoFromConfig c p = unsafeCoerce
 
 -- | Makes a connection to the database via a Client.
 connect :: Pool -> Aff Client
-connect = fromEffectFnAff <<< connect'
+connect = fromEffectFnAff <<< connectImpl
 
 -- | Runs a query and returns nothing.
 execute :: forall a. Query a -> Array SqlValue -> Client -> Aff Unit
@@ -152,7 +152,7 @@ decodeFirst decode rows = decode <$> (rows !! 0)
 
 foreign import mkPool :: ConnectionInfo -> Effect Pool
 
-foreign import connect' :: Pool -> EffectFnAff Client
+foreign import connectImpl :: Pool -> EffectFnAff Client
 
 foreign import runQuery_ :: String -> Client -> EffectFnAff (Array Foreign)
 


### PR DESCRIPTION
Primes in foreign modules exports will be deprecated in v0.14.0. See https://github.com/purescript/purescript/pull/3792.